### PR TITLE
Verbose logs during CI builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
         id: build
         run: |
           gem build parsec.gemspec
-          gem install ./parsecs-*.gem
+          gem install ./parsecs-*.gem --verbose
 
       - name: Tests
         id: tests


### PR DESCRIPTION
# Description ✍️

Enable `--verbose` on CI builds to print out the gem C++ compilation logs.

