### PR TITLE
Create weekyear(date) function

### DIFF
--- a/ext/libnativemath/extconf.rb
+++ b/ext/libnativemath/extconf.rb
@@ -38,7 +38,7 @@ libs.each do |lib|
 end
 
 GIT_REPOSITORY = 'https://github.com/oxeanbits/equations-parser.git'.freeze
-COMMIT = '8769175390cafd9c40b52477f1c97184266c4a68'.freeze
+COMMIT = 'b81e50bc4c43556f8d75566bf0f86a2e71a7ac4e'.freeze
 
 Dir.chdir(BASEDIR) do
   system('git init')

--- a/parsec.gemspec
+++ b/parsec.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name                  = 'parsecs'
-  s.version               = '0.12.0'
+  s.version               = '0.13.0'
   s.platform              = Gem::Platform::RUBY
   s.authors               = ['Nilton Vasques', 'Victor Cordeiro', 'Beatriz Fagundes']
   s.email                 = ['nilton.vasques@gmail.com', 'victorcorcos@gmail.com', 'beatrizsfslima@gmail.com']

--- a/test/test_parsec.rb
+++ b/test/test_parsec.rb
@@ -338,4 +338,38 @@ class TestParsec < Minitest::Test
     assert_equal('apple', parsec.eval_equation('regex("apple123redbanana", "(?=apple)([a-z]+)(?=\\\\d+red)")'))
     assert_equal('apple', parsec.eval_equation('regex("apple123red456banana", "(?=apple)([a-z]+)(?=(\\\\d+red)\\\\d+banana)")'))
   end
+
+  def test_weekyear
+    parsec = Parsec::Parsec
+
+    # Week number of the year when 1st of January is a Sunday
+    assert_equal(1, parsec.eval_equation('weekyear("2023-01-01")'))
+    assert_equal(1, parsec.eval_equation('weekyear("2023-01-07")'))
+    assert_equal(2, parsec.eval_equation('weekyear("2023-01-08")'))
+
+    assert_equal(17, parsec.eval_equation('weekyear("2023-04-25")'))
+    assert_equal(17, parsec.eval_equation('weekyear("2023-04-29")'))
+    assert_equal(18, parsec.eval_equation('weekyear("2023-04-30")'))
+    assert_equal(18, parsec.eval_equation('weekyear("2023-05-06")'))
+
+    assert_equal(52, parsec.eval_equation('weekyear("2023-12-24")'))
+    assert_equal(53, parsec.eval_equation('weekyear("2023-12-31")'))
+
+    # Week number of the year a leap year
+    assert_equal(1, parsec.eval_equation('weekyear("2024-01-01")'))
+    assert_equal(1, parsec.eval_equation('weekyear("2024-01-06")'))
+    assert_equal(2, parsec.eval_equation('weekyear("2024-01-07")'))
+
+    assert_equal(52, parsec.eval_equation('weekyear("2024-12-22")'))
+    assert_equal(53, parsec.eval_equation('weekyear("2024-12-29")'))
+
+    # Week number of the year when 1st of January is friday
+    assert_equal(53, parsec.eval_equation('weekyear("2027-01-01")'))
+    assert_equal(53, parsec.eval_equation('weekyear("2027-01-02")'))
+    assert_equal(1, parsec.eval_equation('weekyear("2027-01-03")'))
+
+    assert_equal(52, parsec.eval_equation('weekyear("2027-12-27")'))
+    assert_equal(52, parsec.eval_equation('weekyear("2027-12-31")'))
+    assert_equal(53, parsec.eval_equation('weekyear("2028-01-01")'))
+  end
 end


### PR DESCRIPTION
## Description
Create the `weekday(date)` function to return the week of year of a
date, based on the ISO week date algorithm:

![image](https://user-images.githubusercontent.com/13650290/234122570-dd78ca39-722f-401f-96e8-8dbe47fc2cc4.png)

> https://en.wikipedia.org/wiki/ISO_week_date

### Usage
```cpp
weekyear("2022-04-20")   // result => 16
