### PR TITLE
 Enable Ruby 3.2 to work in MacOS

### DIFF
--- a/ext/libnativemath/extconf.rb
+++ b/ext/libnativemath/extconf.rb
@@ -73,7 +73,8 @@ end
 Dir.chdir(BASEDIR) do
   Dir.chdir('ext/libnativemath/') do
     system('make')
-    next if OSTYPE.match? 'darwin'
+
+    next if RUBY_PLATFORM.match? 'darwin'
 
     if RUBY_VERSION >= '3.2'
       FileUtils.cp('libnativemath.so', '../../lib/')

--- a/ext/libnativemath/extconf.rb
+++ b/ext/libnativemath/extconf.rb
@@ -73,6 +73,8 @@ end
 Dir.chdir(BASEDIR) do
   Dir.chdir('ext/libnativemath/') do
     system('make')
+    next if OSTYPE.match? 'darwin'
+
     if RUBY_VERSION >= '3.2'
       FileUtils.cp('libnativemath.so', '../../lib/')
     end


### PR DESCRIPTION
# Description ✍️

This PR pretends to fix the Ruby version 3.2 of this Parsec gem not working in MacOS operation systems.


# Overview 🔍



