### PR TITLE
Enable Ruby 3.2 to work in MacOS (2)

### DIFF
--- a/ext/libnativemath/extconf.rb
+++ b/ext/libnativemath/extconf.rb
@@ -40,27 +40,6 @@ end
 GIT_REPOSITORY = 'https://github.com/oxeanbits/equations-parser.git'.freeze
 COMMIT = 'b81e50bc4c43556f8d75566bf0f86a2e71a7ac4e'.freeze
 
-def print_directory_tree(folder_path, indent = 0)
-  # Get the list of files and subdirectories in the current folder
-  entries = Dir.entries(folder_path) - ['.', '..']
-
-  entries.each do |entry|
-    full_path = File.join(folder_path, entry)
-
-    # Check if the entry is a directory
-    if File.directory?(full_path)
-      # Print the directory name with appropriate indentation
-      puts "#{'  ' * indent}#{entry}/"
-
-      # Recursively call the function for the subdirectory
-      print_directory_tree(full_path, indent + 1)
-    else
-      # Print the file name with appropriate indentation
-      puts "#{'  ' * indent}#{entry}"
-    end
-  end
-end
-
 Dir.chdir(BASEDIR) do
   system('git init')
   system("git submodule add #{GIT_REPOSITORY} ext/equations-parser")
@@ -94,10 +73,6 @@ end
 Dir.chdir(BASEDIR) do
   Dir.chdir('ext/libnativemath/') do
     system('make')
-
-    print_directory_tree(Dir.pwd)
-
-    next if RUBY_PLATFORM.match? 'darwin'
 
     if RUBY_VERSION >= '3.2'
       FileUtils.cp('libnativemath.so', '../../lib/')

--- a/ext/libnativemath/extconf.rb
+++ b/ext/libnativemath/extconf.rb
@@ -40,6 +40,27 @@ end
 GIT_REPOSITORY = 'https://github.com/oxeanbits/equations-parser.git'.freeze
 COMMIT = 'b81e50bc4c43556f8d75566bf0f86a2e71a7ac4e'.freeze
 
+def print_directory_tree(folder_path, indent = 0)
+  # Get the list of files and subdirectories in the current folder
+  entries = Dir.entries(folder_path) - ['.', '..']
+
+  entries.each do |entry|
+    full_path = File.join(folder_path, entry)
+
+    # Check if the entry is a directory
+    if File.directory?(full_path)
+      # Print the directory name with appropriate indentation
+      puts "#{'  ' * indent}#{entry}/"
+
+      # Recursively call the function for the subdirectory
+      print_directory_tree(full_path, indent + 1)
+    else
+      # Print the file name with appropriate indentation
+      puts "#{'  ' * indent}#{entry}"
+    end
+  end
+end
+
 Dir.chdir(BASEDIR) do
   system('git init')
   system("git submodule add #{GIT_REPOSITORY} ext/equations-parser")
@@ -73,6 +94,8 @@ end
 Dir.chdir(BASEDIR) do
   Dir.chdir('ext/libnativemath/') do
     system('make')
+
+    print_directory_tree(Dir.pwd)
 
     next if RUBY_PLATFORM.match? 'darwin'
 

--- a/ext/libnativemath/extconf.rb
+++ b/ext/libnativemath/extconf.rb
@@ -57,11 +57,11 @@ Dir.chdir(BASEDIR) do
 end
 
 unless File.exist?("#{MUPARSER_HEADERS}/mpParser.h")
-  abort 'mpParser.h header is missing.'
+  abort 'mpParser.h header is missing!'
 end
 
 unless File.exist?("#{MUPARSER_LIB}/libmuparserx.a")
-  abort 'libmuparserx.a is missing.'
+  abort 'libmuparserx.a is missing!'
 end
 
 if RUBY_VERSION >= '3.2'
@@ -73,6 +73,8 @@ end
 Dir.chdir(BASEDIR) do
   Dir.chdir('ext/libnativemath/') do
     system('make')
+
+    next if RUBY_PLATFORM.match? 'darwin'
 
     if RUBY_VERSION >= '3.2'
       FileUtils.cp('libnativemath.so', '../../lib/')

--- a/ext/libnativemath/extconf.rb
+++ b/ext/libnativemath/extconf.rb
@@ -64,7 +64,7 @@ unless File.exist?("#{MUPARSER_LIB}/libmuparserx.a")
   abort 'libmuparserx.a is missing.'
 end
 
-if RUBY_VERSION >= '3.2' and RUBY_PLATFORM.match? 'linux'
+if RUBY_VERSION >= '3.2'
   create_makefile('../ext/libnativemath')
 else
   create_makefile('ext/libnativemath/libnativemath')

--- a/ext/libnativemath/extconf.rb
+++ b/ext/libnativemath/extconf.rb
@@ -85,7 +85,7 @@ unless File.exist?("#{MUPARSER_LIB}/libmuparserx.a")
   abort 'libmuparserx.a is missing.'
 end
 
-if RUBY_VERSION >= '3.2'
+if RUBY_VERSION >= '3.2' and RUBY_PLATFORM.match? 'linux'
   create_makefile('../ext/libnativemath')
 else
   create_makefile('ext/libnativemath/libnativemath')


### PR DESCRIPTION
# Description ✍️

* The issues

1. `rails s` or `rails c` is not working in MacOS 

```rb
To use retry middleware with Faraday v2.0+, install `faraday-retry` gem
<internal:/Users/victorcosta/.rvm/rubies/ruby-3.2.2/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require': dlopen(/Users/victorcosta/.rvm/gems/ruby-3.2.2@pocket/bundler/gems/parsec-450e19cc9691/ext/libnativemath/libnativemath.bundle, 9): Library not loaded: /Users/victorcosta/.rvm/rubies/ruby-2.5.5/lib/libruby.2.5.dylib (LoadError)
  Referenced from: /Users/victorcosta/.rvm/gems/ruby-3.2.2@pocket/bundler/gems/parsec-450e19cc9691/ext/libnativemath/libnativemath.bundle
  Reason: image not found - /Users/victorcosta/.rvm/gems/ruby-3.2.2@pocket/bundler/gems/parsec-450e19cc9691/ext/libnativemath/libnativemath.bundle
```

2. `make` is also not working in MacOS , it returns an error informing that `'assert.h' file not found`.

```rb
/Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/cassert:20:10: fatal error: 'assert.h' file not found
#include <assert.h>
         ^~~~~~~~~~
```



# Overview 🎨 

* `rails c`

```rb
To use retry middleware with Faraday v2.0+, install `faraday-retry` gem
/Users/victorcosta/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/bundler/gems/apm-agent-ruby-c66819bd21d9/lib/elastic_apm/spies.rb:111:in `require': cannot load such file -- libnativemath (LoadError)
	from /Users/victorcosta/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/bundler/gems/apm-agent-ruby-c66819bd21d9/lib/elastic_apm/spies.rb:111:in `require'
	from /Users/victorcosta/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/zeitwerk-2.6.8/lib/zeitwerk/kernel.rb:38:in `require'
	from /Users/victorcosta/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/bundler/gems/parsec-8f89cdfc6759/lib/parsec.rb:2:in `<top (required)>'
	from /Users/victorcosta/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/bundler/gems/apm-agent-ruby-c66819bd21d9/lib/elastic_apm/spies.rb:111:in `require'
	from /Users/victorcosta/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/bundler/gems/apm-agent-ruby-c66819bd21d9/lib/elastic_apm/spies.rb:111:in `require'
	from /Users/victorcosta/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/zeitwerk-2.6.8/lib/zeitwerk/kernel.rb:38:in `require'
	from /Users/victorcosta/Desktop/repositories/pocket-api/lib/equation_validator.rb:1:in `<top (required)>'
	from /Users/victorcosta/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/bundler/gems/apm-agent-ruby-c66819bd21d9/lib/elastic_apm/spies.rb:111:in `require'
	from /Users/victorcosta/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/bundler/gems/apm-agent-ruby-c66819bd21d9/lib/elastic_apm/spies.rb:111:in `require'
	from /Users/victorcosta/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/zeitwerk-2.6.8/lib/zeitwerk/kernel.rb:38:in `require'
	from /Users/victorcosta/Desktop/repositories/pocket-api/app/validators/column_equation_fields_validator.rb:1:in `<top (required)>'
	from /Users/victorcosta/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/bundler/gems/apm-agent-ruby-c66819bd21d9/lib/elastic_apm/spies.rb:111:in `require'
	from /Users/victorcosta/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/bundler/gems/apm-agent-ruby-c66819bd21d9/lib/elastic_apm/spies.rb:111:in `require'
	from /Users/victorcosta/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/zeitwerk-2.6.8/lib/zeitwerk/kernel.rb:30:in `require'
	from /Users/victorcosta/Desktop/repositories/pocket-api/app/models/column.rb:19:in `<class:Column>'
	from /Users/victorcosta/Desktop/repositories/pocket-api/app/models/column.rb:4:in `<top (required)>'
	from /Users/victorcosta/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/bundler/gems/apm-agent-ruby-c66819bd21d9/lib/elastic_apm/spies.rb:111:in `require'
	from /Users/victorcosta/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/bundler/gems/apm-agent-ruby-c66819bd21d9/lib/elastic_apm/spies.rb:111:in `require'
	from /Users/victorcosta/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/zeitwerk-2.6.8/lib/zeitwerk/kernel.rb:30:in `require'
	from /Users/victorcosta/Desktop/repositories/pocket-api/config/initializers/graphoid.rb:10:in `block in <top (required)>'
	from /Users/victorcosta/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/activesupport-7.0.6/lib/active_support/lazy_load_hooks.rb:92:in `block in execute_hook'
	from /Users/victorcosta/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/activesupport-7.0.6/lib/active_support/lazy_load_hooks.rb:85:in `with_execution_control'
	from /Users/victorcosta/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/activesupport-7.0.6/lib/active_support/lazy_load_hooks.rb:90:in `execute_hook'
	from /Users/victorcosta/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/activesupport-7.0.6/lib/active_support/lazy_load_hooks.rb:76:in `block in run_load_hooks'
	from /Users/victorcosta/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/activesupport-7.0.6/lib/active_support/lazy_load_hooks.rb:75:in `each'
	from /Users/victorcosta/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/activesupport-7.0.6/lib/active_support/lazy_load_hooks.rb:75:in `run_load_hooks'
	from /Users/victorcosta/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/railties-7.0.6/lib/rails/application/finisher.rb:87:in `block in <module:Finisher>'
	from /Users/victorcosta/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/railties-7.0.6/lib/rails/initializable.rb:32:in `instance_exec'
	from /Users/victorcosta/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/railties-7.0.6/lib/rails/initializable.rb:32:in `run'
	from /Users/victorcosta/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/railties-7.0.6/lib/rails/initializable.rb:61:in `block in run_initializers'
	from /Users/victorcosta/.asdf/installs/ruby/3.2.2/lib/ruby/3.2.0/tsort.rb:228:in `block in tsort_each'
	from /Users/victorcosta/.asdf/installs/ruby/3.2.2/lib/ruby/3.2.0/tsort.rb:350:in `block (2 levels) in each_strongly_connected_component'
	from /Users/victorcosta/.asdf/installs/ruby/3.2.2/lib/ruby/3.2.0/tsort.rb:431:in `each_strongly_connected_component_from'
	from /Users/victorcosta/.asdf/installs/ruby/3.2.2/lib/ruby/3.2.0/tsort.rb:349:in `block in each_strongly_connected_component'
	from /Users/victorcosta/.asdf/installs/ruby/3.2.2/lib/ruby/3.2.0/tsort.rb:347:in `each'
	from /Users/victorcosta/.asdf/installs/ruby/3.2.2/lib/ruby/3.2.0/tsort.rb:347:in `call'
	from /Users/victorcosta/.asdf/installs/ruby/3.2.2/lib/ruby/3.2.0/tsort.rb:347:in `each_strongly_connected_component'
	from /Users/victorcosta/.asdf/installs/ruby/3.2.2/lib/ruby/3.2.0/tsort.rb:226:in `tsort_each'
	from /Users/victorcosta/.asdf/installs/ruby/3.2.2/lib/ruby/3.2.0/tsort.rb:205:in `tsort_each'
	from /Users/victorcosta/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/railties-7.0.6/lib/rails/initializable.rb:60:in `run_initializers'
	from /Users/victorcosta/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/railties-7.0.6/lib/rails/application.rb:372:in `initialize!'
	from /Users/victorcosta/Desktop/repositories/pocket-api/config/environment.rb:5:in `<top (required)>'
	from /Users/victorcosta/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/bundler/gems/apm-agent-ruby-c66819bd21d9/lib/elastic_apm/spies.rb:111:in `require'
	from /Users/victorcosta/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/bundler/gems/apm-agent-ruby-c66819bd21d9/lib/elastic_apm/spies.rb:111:in `require'
	from /Users/victorcosta/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/zeitwerk-2.6.8/lib/zeitwerk/kernel.rb:38:in `require'
	from /Users/victorcosta/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/railties-7.0.6/lib/rails/application.rb:348:in `require_environment!'
	from /Users/victorcosta/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/railties-7.0.6/lib/rails/command/actions.rb:28:in `require_environment!'
	from /Users/victorcosta/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/railties-7.0.6/lib/rails/command/actions.rb:15:in `require_application_and_environment!'
	from /Users/victorcosta/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/railties-7.0.6/lib/rails/commands/console/console_command.rb:105:in `perform'
	from /Users/victorcosta/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/thor-1.2.2/lib/thor/command.rb:27:in `run'
	from /Users/victorcosta/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/thor-1.2.2/lib/thor/invocation.rb:127:in `invoke_command'
	from /Users/victorcosta/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/thor-1.2.2/lib/thor.rb:392:in `dispatch'
	from /Users/victorcosta/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/railties-7.0.6/lib/rails/command/base.rb:87:in `perform'
	from /Users/victorcosta/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/railties-7.0.6/lib/rails/command.rb:48:in `invoke'
	from /Users/victorcosta/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/railties-7.0.6/lib/rails/commands.rb:18:in `<top (required)>'
	from bin/rails:4:in `require'
	from bin/rails:4:in `<main>'
```

* `make`

```rb
[  2%] Building CXX object CMakeFiles/muparserx.dir/parser/mpError.cpp.o
In file included from /Users/victorcosta/Desktop/repositories/parsec/ext/equations-parser/parser/mpError.cpp:31:
In file included from /Users/victorcosta/Desktop/repositories/parsec/ext/equations-parser/parser/mpError.h:34:
/Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/cassert:20:10: fatal error: 'assert.h' file not found
#include <assert.h>
         ^~~~~~~~~~
1 error generated.
make[2]: *** [CMakeFiles/muparserx.dir/parser/mpError.cpp.o] Error 1
make[1]: *** [CMakeFiles/muparserx.dir/all] Error 2
make: *** [all] Error 2
```