### PR TITLE
Update Parsec version (Enable Ruby 3.2 to work in MacOS)

### DIFF
--- a/lib/parsec.rb
+++ b/lib/parsec.rb
@@ -6,7 +6,7 @@ module Parsec
   class Parsec
     using StringToBooleanRefinements
 
-    VERSION = '0.11.9'.freeze
+    VERSION = '0.13.1'.freeze
 
     # evaluates the equation and returns only the result
     def self.eval_equation(equation)

--- a/parsec.gemspec
+++ b/parsec.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name                  = 'parsecs'
-  s.version               = '0.13.0'
+  s.version               = '0.13.1'
   s.platform              = Gem::Platform::RUBY
   s.authors               = ['Nilton Vasques', 'Victor Cordeiro', 'Beatriz Fagundes']
   s.email                 = ['nilton.vasques@gmail.com', 'victorcorcos@gmail.com', 'beatrizsfslima@gmail.com']


### PR DESCRIPTION
# Description ✍️

Update the Parsec version to reflect changes of this PR: https://github.com/oxeanbits/parsec/pull/62
And publish it on RubyGems afterwards.


# Overview 🔍




# Checks ☑️

- [x] Update Parsec version with changes in MacOS related libnativemath build
- [ ] Smoke Tests

