### PR TITLE
Update Parsec version (Enable Ruby 3.2 to work in MacOS)

### DIFF
--- a/lib/parsec.rb
+++ b/lib/parsec.rb
@@ -6,7 +6,7 @@ module Parsec
   class Parsec
     using StringToBooleanRefinements
 
-    VERSION = '0.14.0'.freeze
+    VERSION = '0.14.1'.freeze
 
     # evaluates the equation and returns only the result
     def self.eval_equation(equation)


### PR DESCRIPTION
# Description ✍️

Update version from `0.14.0` → `0.14.1`


# Checks ☑️

- [ ] Example

