### PR TITLE
Finally allows Parsec to be used in MacOS Architecture

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "ext/equations-parser"]
 	path = ext/equations-parser
-	url = git@github.com:oxeanbits/equations-parser.git
+	url = git@github.com:Victorcorcos/equations-parser.git

--- a/ext/libnativemath/extconf.rb
+++ b/ext/libnativemath/extconf.rb
@@ -38,7 +38,7 @@ libs.each do |lib|
 end
 
 GIT_REPOSITORY = 'https://github.com/Victorcorcos/equations-parser.git'.freeze
-COMMIT = '6332141'.freeze
+COMMIT = '6332141daff98324c611346a32defd551c73616e'.freeze
 
 Dir.chdir(BASEDIR) do
   system('git init')

--- a/ext/libnativemath/extconf.rb
+++ b/ext/libnativemath/extconf.rb
@@ -74,10 +74,13 @@ Dir.chdir(BASEDIR) do
   Dir.chdir('ext/libnativemath/') do
     system('make')
 
-    next if RUBY_PLATFORM.match? 'darwin'
-
+    # Copy extension file to lib directory for all platforms
     if RUBY_VERSION >= '3.2'
-      FileUtils.cp('libnativemath.so', '../../lib/')
+      if RUBY_PLATFORM.match? 'darwin'
+        FileUtils.cp('ext/libnativemath.bundle', '../../lib/libnativemath.bundle')
+      else
+        FileUtils.cp('libnativemath.so', '../../lib/')
+      end
     end
   end
 end

--- a/ext/libnativemath/extconf.rb
+++ b/ext/libnativemath/extconf.rb
@@ -37,7 +37,7 @@ libs.each do |lib|
   $LOCAL_LIBS << "#{lib} "
 end
 
-GIT_REPOSITORY = 'https://github.com/oxeanbits/equations-parser.git'.freeze
+GIT_REPOSITORY = 'https://github.com/Victorcorcos/equations-parser.git'.freeze
 COMMIT = '6332141'.freeze
 
 Dir.chdir(BASEDIR) do

--- a/ext/libnativemath/extconf.rb
+++ b/ext/libnativemath/extconf.rb
@@ -77,7 +77,7 @@ Dir.chdir(BASEDIR) do
     # Copy extension file to lib directory for all platforms
     if RUBY_VERSION >= '3.2'
       if RUBY_PLATFORM.match? 'darwin'
-        FileUtils.cp('../ext/libnativemath.bundle', '../../lib/libnativemath.bundle')
+        FileUtils.cp('libnativemath.bundle', '../../lib/libnativemath.bundle')
       else
         FileUtils.cp('libnativemath.so', '../../lib/')
       end

--- a/ext/libnativemath/extconf.rb
+++ b/ext/libnativemath/extconf.rb
@@ -77,7 +77,7 @@ Dir.chdir(BASEDIR) do
     # Copy extension file to lib directory for all platforms
     if RUBY_VERSION >= '3.2'
       if RUBY_PLATFORM.match? 'darwin'
-        FileUtils.cp('ext/libnativemath.bundle', '../../lib/libnativemath.bundle')
+        FileUtils.cp('../ext/libnativemath.bundle', '../../lib/libnativemath.bundle')
       else
         FileUtils.cp('libnativemath.so', '../../lib/')
       end

--- a/ext/libnativemath/extconf.rb
+++ b/ext/libnativemath/extconf.rb
@@ -38,7 +38,7 @@ libs.each do |lib|
 end
 
 GIT_REPOSITORY = 'https://github.com/oxeanbits/equations-parser.git'.freeze
-COMMIT = '39d949b5f53d1650eb8f166db3883900f5ce55d4'.freeze
+COMMIT = '6332141'.freeze
 
 Dir.chdir(BASEDIR) do
   system('git init')


### PR DESCRIPTION
# Problem

The `bundle install` command was failing on macOS Sonoma 14.5 when building the parsecs gem with multiple issues:

1. **CMake Compatibility Error**:
   ```
   CMake Error: Compatibility with CMake < 3.5 has been removed from CMake
   ```

2. **Native Extension Loading Error**:
   ```
   cannot load such file -- libnativemath (LoadError)
   ```

## Root Causes

1. The equations-parser has outdated CMake requirements
2. The native extension wasn't being properly copied to the lib directory on macOS for Ruby 3.3+

# Solution

### 1. Updated Submodule Configuration
- Updated the commit hash to use the version with CMake 3.5+ compatibility

### 2. Fixed macOS Native Extension Handling
Updated `extconf.rb` to properly handle macOS bundle files for Ruby 3.3+:

```ruby
# Copy extension file to lib directory for all platforms
if RUBY_VERSION >= '3.2'
  if RUBY_PLATFORM.match? 'darwin'
    FileUtils.cp('libnativemath.bundle', '../../lib/libnativemath.bundle')
  else
    FileUtils.cp('libnativemath.so', '../../lib/')
  end
end
```

**Previous Issue**: The code had `next if RUBY_PLATFORM.match? 'darwin'` which skipped copying the extension on macOS, causing the load error.

## Why This Works

- **CMake Compatibility**: Uses the fixed equations-parser with CMake 3.5+ requirement
- **Proper Extension Loading**: Ensures the native extension is available in the expected location
- **macOS Specific Handling**: Correctly handles `.bundle` files on macOS vs `.so` files on Linux
- **Ruby Version Awareness**: Adapts to Ruby 3.2+ path structure changes

## Testing

- ✅ Successfully builds on macOS Sonoma 14.5 with Ruby 3.3.6
- ✅ `bundle install` completes without errors
- ✅ Native extension loads correctly: `require "parsec"` works
- ✅ Equation evaluation functions properly: `Parsec::Parsec.eval_equation("2 + 3 * 4")` returns `14`
- ✅ Rails application loads successfully with the gem

## Files Changed

- `.gitmodules` - Updated submodule URL
- `ext/libnativemath/extconf.rb` - Fixed macOS extension copying and updated repo references
- Submodule commit updated to fixed version

This fix resolves all compatibility issues with macOS Sonoma while maintaining backward compatibility.